### PR TITLE
Installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ Welcome to the SGMC Pipeline repository! This Python-based information-retrieval
 To use the SGMC Pipeline, you will need the following:
 
 - Python 3.10.6
-- OpenAI API key.
-- Google Maps API key.
-- Google Service Account Key
+- Jupyter Notebook
+
+The following keys are also required at various points in the pipeline.  Instructions on how to generate each key are included in the notebook file where each one is required:
+
+- Google Service Account Key 
+- OpenAI API key 
+- Google Maps API key 
 
 ## Installation options
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following keys are also required at various points in the pipeline.  Instruc
 
 To get started with the SGMC Pipeline, follow these steps:
 
-1. Clone the repository to your local machine:
+1. Navigate to the directory where you want to install the repository, and then clone the repository to your local machine:
 
 ```shell
 $ git clone https://github.com/CDCgov/PASS.git
@@ -30,7 +30,7 @@ $ git clone https://github.com/CDCgov/PASS.git
 2. Navigate to the repository directory:
 
 ```shell
-$ cd SGMC
+$ cd PASS/SGMC
 ```
 
 3. Install the required dependencies:
@@ -42,7 +42,7 @@ $ pip install -r requirements.txt
 
 To get started with the SGMC Pipeline, follow these steps:
 
-1. Clone the repository to your local machine:
+1. Navigate to the directory where you want to install the repository, and then clone the repository to your local machine:
 
 ```shell
 $ git clone https://github.com/CDCgov/PASS.git
@@ -51,7 +51,7 @@ $ git clone https://github.com/CDCgov/PASS.git
 2. Navigate to the repository directory:
 
 ```shell
-$ cd SGMC
+$ cd PASS/SGMC
 ```
 
 3. Install the Poetry:
@@ -65,13 +65,13 @@ $ pip install poetry
 $ poetry shell
 ```
 
-4. Create jupyter kernel:
+5. Create jupyter kernel:
 
 ```shell
 $ poetry run ipython kernel install --user --name=sgmc_kernel
 $ jupyter notebook
 ```
-And then select the created kernel in “Kernel” -> “Change kernel”.
+And then select the created kernel in “Kernel” -> “Change kernel” -> "sgmc_kernel".  Make certain that the "sgmc_kernel" is selected in each notebook file.
 
 ## Usage
 


### PR DESCRIPTION
Suggested changes to help a brand new user start to use the pipeline.
1. Added “Jupyter notebook” under the Prerequisites. 
2. There are some notes on the installation of the OpenAI API key, Google Maps API key, Google Service Account key in the specific notebook files, but because they were listed in the prerequisites, I installed them all before hand without knowing about the links provided in the notebook.  I added additional comments to reflect that there are more instructions in the specific notebook files.
3. Added a note before running the git clone command (for both the pip and poetry instructions), to be sure to navigate into the directory you want to install the PASS/SGMC directory into. 
4. In the installation commands (for both pip and poetry), under step “2. Navigate to the repository directory”, when you run the git clone command, it installs into ./PASS/SGMC, so the user needs to cd PASS/SGMC, not just SGMC. 
5. Under the poetry instructions, I added a note that you need to select the created kernel in each notebook file.  I needed to do this with an earlier Notebook install, but I just updated Jupyter notebook on my machine, and this may not be needed with the latest installs...