### PR TITLE
00_SRA_Cloud_metadata changes

### DIFF
--- a/SGMC/00_SRA_Cloud_metadata.ipynb
+++ b/SGMC/00_SRA_Cloud_metadata.ipynb
@@ -10,9 +10,13 @@
     "\n",
     "In this notebook we use BigQuery API client to get SRA center_names for a given accession target list.\n",
     "\n",
-    "This notebook requires a GCP service account, use the following links to create an account: https://cloud.google.com/iam/docs/service-accounts-create#creating\n",
+    "This notebook requires a Google Cloud Platform (GCP) service account, use the following links to create an account: https://cloud.google.com/iam/docs/service-accounts-create#creating\n",
     "\n",
-    "and read the associated reference: https://googleapis.dev/python/google-api-core/latest/auth.html#service-accounts"
+    "and read the associated reference: https://googleapis.dev/python/google-api-core/latest/auth.html#service-accounts\n",
+    "\n",
+    "Then, use the following link for instructions on how to create a GCP service account key: https://cloud.google.com/iam/docs/keys-create-delete\n",
+    "\n",
+    "You will need to enter the path to the JSON service account key file when prompted below."
    ]
   },
   {

--- a/SGMC/00_SRA_Cloud_metadata.ipynb
+++ b/SGMC/00_SRA_Cloud_metadata.ipynb
@@ -78,12 +78,31 @@
    "execution_count": 3,
    "id": "e54ec63d-fc1b-45e2-b1fb-2636a0123965",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the file path to your GCP key file (e.g. C:\\Users\\user\\testkeyfile.json or /home/user/testkeyfile.json) and press enter: C:\\Users\\rflod\\Desktop\\CDCWork\\testgh-391320-fd62dad18bef.json\n"
+     ]
+    }
+   ],
    "source": [
+    "import os\n",
+    "\n",
     "from google.oauth2 import service_account\n",
     "\n",
-    "credentials = service_account.Credentials.from_service_account_file(\n",
-    "    './keyfile.json')\n"
+    "# Get the file path to the GCP key file\n",
+    "key_file = input('Enter the file path to your GCP key file (e.g. C:\\\\Users\\\\user\\\\testkeyfile.json or /home/user/testkeyfile.json) and press enter:') \n",
+    "\n",
+    "# Check to make certain the path exists and either get the credentials or return an error message\n",
+    "if os.path.exists(key_file):\n",
+    "    \n",
+    "    credentials = service_account.Credentials.from_service_account_file(key_file)\n",
+    "    \n",
+    "else: \n",
+    "    \n",
+    "    print('Error: No such file or directory is found')"
    ]
   },
   {


### PR DESCRIPTION
I made a few changes to hopefully make it easier for a user to enter their GCP service account key file. 

1. In the instructions section at the top of the page, I added a link to the instructions to generate a GCP service account key file (JSON type is recommended on this page).  I also noted that they will need to enter the path to the JSON key file they create when prompted by the notebook page.

2.  I also changed the code to prompt the user for this JSON key file path instead of having the user change the code to edit the file path.  I only added one small check to make certain that the file path exists.