### PR TITLE
Added print statement about progress bar completion

### DIFF
--- a/SGMC/01_NCBI_webScrape.ipynb
+++ b/SGMC/01_NCBI_webScrape.ipynb
@@ -112,6 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "print('Note: The following process is complete when all four progress bars display 100%.')\n",
     "df = pd.read_csv('./data/input/sample_data.csv')\n",
     "df['Submitted_by'] = df['Acc'].progress_apply(find_submited_by)\n",
     "df['ID'] = df['Acc'].progress_apply(find_ID)\n",


### PR DESCRIPTION
Change in 01_NCBI_webScrape file:
Not knowing Python, it took me a bit to figure out that there would be 4 progress bars, so I added a print statement to tell the user how to know once the code chuck containing the progress bars is all completed.