### PR TITLE
03_geolocator_google_api changes

### DIFF
--- a/SGMC/03_geolocator_google_API.ipynb
+++ b/SGMC/03_geolocator_google_API.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Google Maps Geocoding API\n",
-    "Creating API keys\n",
+    "Creating API keys:\n",
     "The API key is a unique identifier that authenticates requests associated with your project for usage and billing purposes. You must have at least one API key associated with your project.\n",
     "\n",
     "To create an API key:\n",
@@ -47,9 +47,9 @@
    "outputs": [],
    "source": [
     "API_ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json'\n",
-    "API_KEY= input('Enter your Google Maps API Key please')\n",
+    "API_KEY= input('Please enter your Google Maps API Key and press Enter:')\n",
     "if API_KEY != '':\n",
-    "    print(f'API Key Entered successfully, Last seven charaters: {API_KEY[:7]}')\n",
+    "    print(f'API Key Entered successfully, Last seven charaters: {API_KEY[len(API_KEY)-7:]}')\n",
     "else:\n",
     "    print('Enter valid API Key')\n",
     "    exit()"

--- a/SGMC/03_geolocator_google_API.ipynb
+++ b/SGMC/03_geolocator_google_API.ipynb
@@ -128,7 +128,11 @@
     "        # If geocoding fails, set the latitude, longitude, and full address columns to empty strings\n",
     "        df.loc[i, 'Google_Maps_Latitude'] = ''\n",
     "        df.loc[i, 'Google_Maps_Longitude'] = ''\n",
-    "        df.loc[i, 'Google_Maps_Full Address'] = ''"
+    "        df.loc[i, 'Google_Maps_Full Address'] = ''\n",
+    "\n",
+    "if len(df[df['Google_Maps_Latitude'] == ''])==len(df) & len(df[df['Google_Maps_Longitude'] == ''])==len(df) & len(df[df['Google_Maps_Full Address'] == ''])==len(df):\n",
+    "    # Add warning that this all empty strings were returned.  Ask user to double check API key\n",
+    "    print('Warning: Geocoding has failed.  Empty strings were returned for Latitude, Longitude, and Full Address fields. \\n Please check that your API key is valid.')"
    ]
   },
   {


### PR DESCRIPTION
I made the following changes to the 03_geolocator_google_api file:
1.	When entering key added comment to “press Enter”.
2.	The first seven characters are printed of the key, not the last.  I changed the code to print the last 7 characters.
3.	I added a warning if the geocoding fails, and all empty strings are returned for the lat, long, and full address fields.  I also added a note to tell the user to check their API key.
